### PR TITLE
Feature: add !pp command

### DIFF
--- a/websocket.js
+++ b/websocket.js
@@ -65,16 +65,15 @@ async function handleWebSocketMessage(data) {
                                 break;
                         };
 
-                        if (data.payload.event.message.text.trim().split(" ")[0] == "!pp") {
-                            var percentage = parseInt(data.payload.event.message.text.trim().split(" ")[1], 10);
-                            console.log(typeof percentage, percentage);
+                        var split_message = data.payload.event.message.text.trim().split(" ");
+                        if (split_message[0] == "!pp") {
+                            var percentage = parseFloat(split_message[1]).toFixed(2);
                             if (percentage >= 0 && percentage <= 100) {
                                 var timeNow = new Date().getTime();
                                 if ((!timeThen) || (timeNow - timeThen > cooldown.value * 1000)) {
                                     sendChatMessage(`@${data.payload.event.chatter_user_name} | ${await fetchData("map")} |${await fetchData("pp")} ${percentage}%: ${await calculatePp(percentage)}pp`);
                                     timeThen = timeNow;
                                 };
-
                             }
                         }
                     break;

--- a/websocket.js
+++ b/websocket.js
@@ -62,7 +62,21 @@ async function handleWebSocketMessage(data) {
                                     sendChatMessage(`@${data.payload.event.chatter_user_name} | ${await fetchData("map")}`);
                                     timeThen = timeNow;
                                 };
+                                break;
                         };
+
+                        if (data.payload.event.message.text.trim().split(" ")[0] == "!pp") {
+                            var percentage = parseInt(data.payload.event.message.text.trim().split(" ")[1], 10);
+                            console.log(typeof percentage, percentage);
+                            if (percentage >= 0 && percentage <= 100) {
+                                var timeNow = new Date().getTime();
+                                if ((!timeThen) || (timeNow - timeThen > cooldown.value * 1000)) {
+                                    sendChatMessage(`@${data.payload.event.chatter_user_name} | ${await fetchData("map")} |${await fetchData("pp")} ${percentage}%: ${await calculatePp(percentage)}pp`);
+                                    timeThen = timeNow;
+                                };
+
+                            }
+                        }
                     break;
                     };
             };


### PR DESCRIPTION
This pull request adds the `!pp <accuracy>` command to the bot.

It splits the chat message and gets the accuracy if it starts with '!pp'. The accuracy string is then converted to a float using `parseFloat()` so it should be safe. This way both `!pp 88` and `!pp 88%` work and output the same thing.